### PR TITLE
Update bugtracker link to the new repository

### DIFF
--- a/com.bitwarden.desktop.appdata.xml
+++ b/com.bitwarden.desktop.appdata.xml
@@ -53,7 +53,7 @@
     </screenshot>
   </screenshots>
   <url type="homepage">https://www.bitwarden.com/</url>
-  <url type="bugtracker">https://github.com/bitwarden/desktop/issues/</url>
+  <url type="bugtracker">https://github.com/bitwarden/clients/issues/</url>
   <url type="help">https://bitwarden.com/help/</url>
   <developer_name>8bit Solutions LLC</developer_name>
   <update_contact>hello@bitwarden.com</update_contact>


### PR DESCRIPTION
The currently linked repo says that the project moved:

> This repository is archived, please go to https://github.com/bitwarden/clients for future development.