### PR TITLE
Use Bitwarden Desktop Version in metainfo

### DIFF
--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -46,6 +46,7 @@ modules:
           type: anitya
           project-id: 179174
           url-template: https://github.com/bitwarden/clients/releases/download/desktop-v$version/Bitwarden-$version-amd64.deb
+          is-main-source: true
       - type: script
         dest-filename: bitwarden.sh
         commands:


### PR DESCRIPTION
Make sure that flatpak-external-data-checker puts the Bitwarden Desktop Version into the metainfo file and not the bitwarden cli version.