### PR TITLE
allow bitwarden to talk to org.freedesktop.login1

### DIFF
--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=x11
   - --device=dri
   - --env=XDG_CURRENT_DESKTOP=Unity
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   - --system-talk-name=org.freedesktop.login1
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications

--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=x11
   - --device=dri
   - --env=XDG_CURRENT_DESKTOP=Unity
+  - --system-talk-name=org.freedesktop.login1
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets

--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -12,7 +12,6 @@ finish-args:
   - --socket=x11
   - --device=dri
   - --env=XDG_CURRENT_DESKTOP=Unity
-  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   - --system-talk-name=org.freedesktop.login1
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications


### PR DESCRIPTION
This fixes errors like coming from electron https://github.com/electron/electron/blob/main/shell/browser/lib/power_observer_linux.cc:
```
Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
```
For more discussion see https://github.com/flathub/com.bitwarden.desktop/pull/99