### PR TITLE
Revert "Enable wayland by default, fallback to X11 (#99)"

### DIFF
--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -9,7 +9,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --device=dri
   - --env=XDG_CURRENT_DESKTOP=Unity
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
@@ -63,7 +63,7 @@ modules:
         dest-filename: bitwarden.sh
         commands:
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
-          - exec zypak-wrapper /app/Bitwarden/bitwarden --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations "$@"
+          - exec zypak-wrapper /app/Bitwarden/bitwarden "$@"
       - type: file
         path: com.bitwarden.desktop.metainfo.xml
 

--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -63,7 +63,7 @@ modules:
         dest-filename: bitwarden.sh
         commands:
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
-          - exec zypak-wrapper /app/Bitwarden/bitwarden "$@"
+          - exec zypak-wrapper /app/Bitwarden/bitwarden --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations "$@"
       - type: file
         path: com.bitwarden.desktop.metainfo.xml
 


### PR DESCRIPTION
Using Wayland by default with Bitwarden currently breaks copy/paste functionality. Given that this is fundamental functionality for a password manager, revert the use of Wayland by default until this is solved.