### PR TITLE
Drop `org.freedesktop.portal.*` permissions

### DIFF
--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -16,7 +16,6 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
-  - --talk-name=org.freedesktop.portal.Background
   - --talk-name=com.canonical.AppMenu.Registrar
   - --system-talk-name=org.freedesktop.login1
   - --filesystem=xdg-download


### PR DESCRIPTION
No longer required.

Closes #180