### PR TITLE
Drop libsecret from manifest

### DIFF
--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -22,8 +22,6 @@ finish-args:
 rename-desktop-file: bitwarden.desktop
 rename-icon: bitwarden
 modules:
-  - shared-modules/libsecret/libsecret.json
-
   - name: bitwarden-desktop
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
It is now provided by the Electron runtime.

Closes #182