### PR TITLE
Allow access to system lock dbus interfaces

### DIFF
--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -17,6 +17,9 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
   - --talk-name=com.canonical.AppMenu.Registrar
+    # Lock on lockscreen
+  - --talk-name=org.gnome.ScreenSaver
+  - --talk-name=org.freedesktop.ScreenSaver
   - --system-talk-name=org.freedesktop.login1
   - --filesystem=xdg-download
 rename-desktop-file: bitwarden.desktop


### PR DESCRIPTION
Upstream PR:
https://github.com/bitwarden/clients/pull/9645

Enables vault timeout on system lock on desktop environments that provide this information via dbus org.freedesktop.ScreenSaver/org.gnome.ScreenSaver. Tested on a local development build.