### PR TITLE
Use freedesktop 24.08 SDK & runtime

### DIFF
--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -1,9 +1,9 @@
 app-id: com.bitwarden.desktop
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 command: bitwarden
 finish-args:
   - --share=ipc


### PR DESCRIPTION
As the new stable version of Freedesktop SDK is released. This PR updates the SDK and runtime to freedesktop 24.08.