### PR TITLE
Remove unofficial notice

### DIFF
--- a/com.bitwarden.desktop.metainfo.xml
+++ b/com.bitwarden.desktop.metainfo.xml
@@ -39,9 +39,6 @@
       is hosted on GitHub and everyone is free to review, audit, and
       contribute to the Bitwarden codebase.
     </p>
-    <p>
-      This wrapper is not verified by, affiliated with, or supported by Bitwarden Inc.
-    </p>
   </description>
   <categories>
     <category>Utility</category>


### PR DESCRIPTION
Removes the note that the wrapper is unofficial, since it is now under Bitwarden maintenance. Verification of the FlatHub page is in-progress.