### PR TITLE
Permissions: Switch from x11 to fallback-x11

### DIFF
--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -9,7 +9,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=wayland
-  - --socket=x11
+  - --socket=fallback-x11
   - --device=dri
   - --env=XDG_CURRENT_DESKTOP=Unity
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons


### PR DESCRIPTION
Bitwarden doesn't need to run Wayland+X11 at the same time, fallback-x11 allows to use the recommended one and block access to the other Bitwarden also seems to run fine with Wayland

This means Bitwarden cannot potentially spy on other X11 apps when Wayland is being used anyway, when the user uses Wayland + XWayland