### PR TITLE
sandbox: xdg-download is no longer needed for desktop environments with portals

### DIFF
--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -21,7 +21,6 @@ finish-args:
   - --talk-name=org.gnome.ScreenSaver
   - --talk-name=org.freedesktop.ScreenSaver
   - --system-talk-name=org.freedesktop.login1
-  - --filesystem=xdg-download
 rename-desktop-file: bitwarden.desktop
 rename-icon: bitwarden
 modules:


### PR DESCRIPTION
portals seem to be working again, and the user is then able to export to whatever directory they want, without Bitwarden needing access to these