### PR TITLE
[PM-18884] Add permission for fido2 security keys

### DIFF
--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -22,6 +22,8 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --system-talk-name=org.freedesktop.login1
   - --filesystem=xdg-download
+  # Fido2 USB security keys
+  - --device=all
 rename-desktop-file: bitwarden.desktop
 rename-icon: bitwarden
 modules:


### PR DESCRIPTION
Adds the permission change from `clients` to the flathub manifest:
https://github.com/bitwarden/clients/pull/13038