### PR TITLE
[PM-24086] enable wayland support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,3 @@
 
 Please point issues with the flatpak release to https://github.com/bitwarden/clients/issues.
 
-## Experimental Wayland support
-
-Electron (the technology used to build the Bitwarden Desktop app) may not play nicely with Wayland at the current moment, especially in GNOME.
-Regardless, you have the ability to try out Wayland by setting the environment variable `ELECTRON_OZONE_PLATFORM_HINT=auto` and giving access to the Wayland socket.
-
-```sh
-flatpak override --user --env=ELECTRON_OZONE_PLATFORM_HINT=auto com.bitwarden.desktop
-flatpak override --user --socket=wayland com.bitwarden.desktop
-```
-
-When using Wayland, it is also safe to disable X11 and IPC access from the Flatpak sandbox.
-
-```sh
-flatpak override --user --nosocket=x11 com.bitwarden.desktop
-flatpak override --user --unshare=ipc com.bitwarden.desktop
-```
-
-You can also use [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) to manage these via a GUI.

--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -8,7 +8,9 @@ command: bitwarden
 finish-args:
   - --share=ipc
   - --share=network
-  - --socket=fallback-x11
+  # This should be fallback-x11, but on gnome/mutter, zwlr_data_control_manager_v1 is not implemented
+  # so we need to use x11 as a fallback to make copy paste work
+  - --socket=x11
   - --socket=wayland
   - --device=dri
   - --env=XDG_CURRENT_DESKTOP=Unity

--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -9,6 +9,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=x11
+  - --socket=wayland
   - --device=dri
   - --env=XDG_CURRENT_DESKTOP=Unity
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons

--- a/com.bitwarden.desktop.yaml
+++ b/com.bitwarden.desktop.yaml
@@ -8,7 +8,7 @@ command: bitwarden
 finish-args:
   - --share=ipc
   - --share=network
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --device=dri
   - --env=XDG_CURRENT_DESKTOP=Unity


### PR DESCRIPTION
> [!NOTE]  
> edit: Tracking link: https://bitwarden.atlassian.net/browse/PM-24086 - @quexten 

running with --socket=wayland and --ozone-platform-hint=auto enables this to run natively under wayland. I've been running it like this for a while with no visible drawbacks. Without providing the --ozone-platform-hint=auto it still launches by default on xwayland.